### PR TITLE
[SIS-71] 存在しないURLを指定した場合404ページを表示する

### DIFF
--- a/src/features/Error/NotFound/NotFoundContainer.tsx
+++ b/src/features/Error/NotFound/NotFoundContainer.tsx
@@ -1,0 +1,5 @@
+import { NotFoundPresentational } from './NotFoundPresentational'
+
+export const NotFoundContainer = () => {
+  return <NotFoundPresentational />
+}

--- a/src/features/Error/NotFound/NotFoundPresentational.tsx
+++ b/src/features/Error/NotFound/NotFoundPresentational.tsx
@@ -1,0 +1,16 @@
+import { Container, Box, VStack } from '@chakra-ui/react'
+
+export const NotFoundPresentational = () => {
+  return (
+    <>
+      <Container minH='100vh' display='flex' alignItems='center' justifyContent='center' py={8}>
+        <VStack>
+          <Box fontSize='7xl' fontWeight='bold' color='blue.500'>
+            404
+          </Box>
+          <Box fontSize='3xl'>Page Not Found</Box>
+        </VStack>
+      </Container>
+    </>
+  )
+}

--- a/src/features/Error/NotFound/__test__/NotFoundContainer.test.tsx
+++ b/src/features/Error/NotFound/__test__/NotFoundContainer.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+
+import { customRender } from '@/tests/helpers/customRender'
+import { NotFoundContainer } from '../NotFoundContainer'
+import * as Presentational from '../NotFoundPresentational'
+
+// Mocking the NotFoundPresentational component
+vi.spyOn(Presentational, 'NotFoundPresentational').mockImplementation(() => {
+  return <div data-testid='mock-presentational'>Mocked NotFoundPresentational</div>
+})
+
+describe('NotFoundContainer', () => {
+  it('NotFoundPresentationalコンポーネントが表示される', () => {
+    customRender(<NotFoundContainer />)
+
+    expect(screen.getByTestId('mock-presentational')).toBeInTheDocument()
+  })
+})

--- a/src/features/Error/NotFound/__test__/NotFoundPresentational.test.tsx
+++ b/src/features/Error/NotFound/__test__/NotFoundPresentational.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+
+import { customRender } from '@/tests/helpers/customRender'
+import { NotFoundPresentational } from '../NotFoundPresentational'
+
+describe('NotFoundPresentational', () => {
+  it('「404」と「Page Not Found」が表示される', () => {
+    customRender(<NotFoundPresentational />)
+
+    expect(screen.getByText('404')).toBeInTheDocument()
+    expect(screen.getByText('Page Not Found')).toBeInTheDocument()
+  })
+})

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -2,6 +2,7 @@
 import { Route, Routes } from 'react-router-dom'
 // src/routes/user/baseファイルのUserBaseRouter関数を読み込み
 import { MainBaseRouter } from 'src/routes/main/base'
+import { NotFoundContainer } from '@/features/Error/NotFound/NotFoundContainer'
 
 // export：外部から参照できるようにするためのもの
 export const AppRouter = () => {
@@ -9,6 +10,8 @@ export const AppRouter = () => {
     <>
       <Routes>
         <Route path='/main/*' element={<MainBaseRouter />} />
+        <Route path='*' element={<NotFoundContainer />} />{' '}
+        {/* 定義したどのpathにもマッチしないURLが来たら、*（ワイルドカード）がマッチ */}
       </Routes>
     </>
   )


### PR DESCRIPTION
### 概要
- 404ページの作成およびテストの実施

## 変更点
- 以下のファイルを追加
  - src/features/Error/NotFound/NotFoundContainer.tsx
  - src/features/Error/NotFound/__test__/NotFoundContainer.test.tsx
  - src/features/Error/NotFound/NotFoundPresentational.tsx
  - src/features/Error/NotFound/__test__/NotFoundPresentational.test.tsx
 - 以下のファイルを修正
   - src/routes/home.tsx

## 画面表示
- 404ページ画面表示
<img width="1461" height="772" alt="404ページ画面表示" src="https://github.com/user-attachments/assets/36f581c4-b6ab-4bf6-8fad-ff68f3983947" />

## 影響範囲
- 全体設定：存在しないURLにアクセスした際に、404ページに遷移するようにした。

## テスト
- 以下のファイルの単体テストを実施し、問題がないこと確認
  - NotFoundContainer.tsx
  - NotFoundPresentational.tsx

## 該当タスク
- https://novel-team.atlassian.net/browse/SIS-71?atlOrigin=eyJpIjoiYTQwMGQ4NzA3NDFhNDc5ODhkNjA0OWQ1MjU1NDFhMmEiLCJwIjoiaiJ9